### PR TITLE
Reduced min-length allowed for PolymorphicPersistentObject name to 4

### DIFF
--- a/src/PHPFrame/Mapper/PolymorphicPersistentObject.php
+++ b/src/PHPFrame/Mapper/PolymorphicPersistentObject.php
@@ -40,7 +40,7 @@ abstract class PHPFrame_PolymorphicPersistentObject
             "type",
             get_class($this),
             false,
-            new PHPFrame_StringFilter(array("min_length"=>6, "max_length"=>100))
+            new PHPFrame_StringFilter(array("min_length"=>4, "max_length"=>100))
         );
         $this->addField(
             "params",


### PR DESCRIPTION
Can now use all of those handy four-letter words for table names..
Closes issue #24
https://github.com/PHPFrame/PHPFrame/issues/24
