### PR TITLE
Optional Beautifier in XMLRenderer when not using Document

### DIFF
--- a/src/PHPFrame/Document/XMLRenderer.php
+++ b/src/PHPFrame/Document/XMLRenderer.php
@@ -26,6 +26,13 @@
 class PHPFrame_XMLRenderer extends PHPFrame_Renderer
 {
     private $_root_node_name = "root";
+    /**
+     * A boolean indicating whether or not to use the XML beautifier when
+     * converting to string.
+     *
+     * @var bool
+     */
+    private $_use_beautifier=true;
 
     public function rootNodeName($str=null)
     {
@@ -48,6 +55,8 @@ class PHPFrame_XMLRenderer extends PHPFrame_Renderer
     {
         if ($value instanceof Exception) {
             $value = $this->exceptionToArray($value);
+        } elseif ($value instanceof PHPFrame_RESTfulObject) {
+            $value = $value->getRESTfulRepresentation();
         } elseif ($value instanceof PHPFrame_PersistentObject) {
             $value = $this->persistentObjectToArray($value);
         } elseif ($value instanceof PHPFrame_PersistentObjectCollection) {
@@ -58,6 +67,25 @@ class PHPFrame_XMLRenderer extends PHPFrame_Renderer
             return (string) $value;
         }
 
-        return PHPFrame_XMLSerialiser::serialise($value, $this->rootNodeName());
+        return PHPFrame_XMLSerialiser::serialise($value, $this->rootNodeName(), $this->_use_beautifier);
+    }
+    
+    /**
+     * Set whether or not to use the XML beautifier when converting to string.
+     *
+     * @param bool $bool [Optional] Boolean indicating whether or not to use
+     *                   the beautifier. If not passed this method simply
+     *                   returns the current value.
+     *
+     * @return bool
+     * @since  1.0
+     */
+    public function useBeautifier($bool=null)
+    {
+        if (!is_null($bool)) {
+            $this->_use_beautifier = (bool) $bool;
+        }
+
+        return $this->_use_beautifier;
     }
 }

--- a/src/PHPFrame/MVC/RESTfulController.php
+++ b/src/PHPFrame/MVC/RESTfulController.php
@@ -229,6 +229,7 @@ abstract class PHPFrame_RESTfulController extends PHPFrame_ActionController
             $response->document(new PHPFrame_XMLDocument());
             $response->document()->useBeautifier(false);
             $response->renderer(new PHPFrame_XMLRenderer());
+            $response->renderer()->useBeautifier(false);
             $response->renderer()->rootNodeName("api-response");
             break;
 

--- a/src/PHPFrame/Utils/XMLSerialiser.php
+++ b/src/PHPFrame/Utils/XMLSerialiser.php
@@ -29,11 +29,12 @@ class PHPFrame_XMLSerialiser
      *
      * @param mixed  $value          The value we want to serialise to XML.
      * @param string $root_node_name [Optional]
+     * @param bool $beautify [Optional] Get pretty XML
      *
      * @return string
      * @since  1.0
      */
-    public static function serialise($value, $root_node_name="root")
+    public static function serialise($value, $root_node_name="root", $beautify=false)
     {
         // Build serialised string
         $str = self::_doSerialise($value);
@@ -42,11 +43,16 @@ class PHPFrame_XMLSerialiser
             $str = "<".$root_node_name.">".$str."</".$root_node_name.">";
         }
 
-        // Get instance of beautifier to make string look pretty ;-)
-        $xml_beautifier = new XML_Beautifier();
-
-        // Return beautified string
-        return $xml_beautifier->formatString($str);
+        if ($beautify) {
+        	
+	        // Get instance of beautifier to make string look pretty ;-)
+	        $xml_beautifier = new XML_Beautifier();
+	
+	        // Get beautified string
+	        $str = $xml_beautifier->formatString($str);
+        }
+         
+	    return $str;
     }
 
     /**


### PR DESCRIPTION
Using RESTfulController, we allow a return formatted in XML. The Document is never used here and this resulted in XML_Beautifier always being used. We need the ability to avoid using Beautifier, so here's a small change to allow for just that.

Please pull & include this in the next build if you can. 
